### PR TITLE
feat: add object, basic_window<CI>, root_window<CI>

### DIFF
--- a/src/errors.hpp
+++ b/src/errors.hpp
@@ -1,0 +1,15 @@
+#ifndef SRC_ERRORS_HPP
+#define SRC_ERRORS_HPP
+
+#include "ncurses.hpp"
+
+enum tasker_error : int {
+    ERROR = ERR,
+    SUCCESS = OK,
+    ERROR_INITSCR = 1,
+    ERROR_KEYPAD = 2,
+    ERROR_RAW = 3,
+    ERROR_ECHO = 4,
+};
+
+#endif /* SRC_ERRORS_HPP */

--- a/src/tests/main.test.cpp
+++ b/src/tests/main.test.cpp
@@ -12,13 +12,12 @@ TEST(main, initscr_fails)
 {
     tasker::ext::mock_ncurses ncurses;
     EXPECT_CALL(ncurses, initscr()).WillOnce(Return(nullptr));
-    EXPECT_CALL(ncurses, endwin()).WillOnce(Return(0));
 
     const char *_argv[] = { PROG, nullptr };
     auto argv = const_cast<char **>(_argv);
 
     auto rc = tasker_main(ncurses, 1, argv);
-    ASSERT_EQ(rc, 1);
+    ASSERT_EQ(rc, ERROR_INITSCR);
 }
 
 TEST(main, keypad_fails)
@@ -34,7 +33,7 @@ TEST(main, keypad_fails)
     auto argv = const_cast<char **>(_argv);
 
     auto rc = tasker_main(ncurses, 1, argv);
-    ASSERT_EQ(rc, 2);
+    ASSERT_EQ(rc, ERROR_KEYPAD);
 }
 
 TEST(main, raw_fails)
@@ -51,7 +50,7 @@ TEST(main, raw_fails)
     auto argv = const_cast<char **>(_argv);
 
     auto rc = tasker_main(ncurses, 1, argv);
-    ASSERT_EQ(rc, 3);
+    ASSERT_EQ(rc, ERROR_RAW);
 }
 
 TEST(main, noecho_fails)
@@ -69,7 +68,7 @@ TEST(main, noecho_fails)
     auto argv = const_cast<char **>(_argv);
 
     auto rc = tasker_main(ncurses, 1, argv);
-    ASSERT_EQ(rc, 4);
+    ASSERT_EQ(rc, ERROR_ECHO);
 }
 
 TEST(main, runs)
@@ -78,7 +77,7 @@ TEST(main, runs)
     auto argv = const_cast<char **>(_argv);
 
     auto rc = main_real(1, argv);
-    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(rc, SUCCESS);
 
     // main() sets keypad(root_win, true); let's assert that it did.
     auto ncurses = tasker::ext::ncurses();

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -59,3 +59,12 @@ tui_test = executable(
   include_directories : inc,
 )
 test('tui test', tui_test)
+
+window_test = executable(
+  'window.test',
+  'window.test.cpp',
+  dependencies : test_deps,
+  link_with : [tasker_lib],
+  include_directories : inc,
+)
+test('window test', window_test)

--- a/src/tests/tui.test.cpp
+++ b/src/tests/tui.test.cpp
@@ -26,6 +26,8 @@ public:
     {
         EXPECT_CALL(ncurses, initscr()).WillOnce(Return(&mock_win));
         EXPECT_CALL(ncurses, keypad(_, _)).WillOnce(Return(OK));
+        EXPECT_CALL(ncurses, raw()).WillOnce(Return(OK));
+        EXPECT_CALL(ncurses, noecho()).WillOnce(Return(OK));
         EXPECT_CALL(ncurses, endwin()).WillOnce(Return(OK));
     }
 };

--- a/src/tests/window.test.cpp
+++ b/src/tests/window.test.cpp
@@ -1,0 +1,10 @@
+#include "../tui/window.hpp"
+#include <gtest/gtest.h>
+using namespace tasker;
+
+TEST(root_window, ncurses_null)
+{
+    tui::root_window<ext::ncurses> root;
+    ASSERT_EQ(root.init(), ERROR);
+    ASSERT_EQ(root.refresh(), ERROR);
+}

--- a/src/tui/object.hpp
+++ b/src/tui/object.hpp
@@ -1,0 +1,30 @@
+#ifndef SRC_TUI_OBJECT_HPP
+#define SRC_TUI_OBJECT_HPP
+
+namespace tasker::tui
+{
+
+/**
+ * @brief Base TUI object interface
+ *
+ * This class should be used as a base for any types derivative
+ * of an ncurses WINDOW.
+ **/
+class object
+{
+public:
+    virtual ~object() noexcept = default;
+
+    //! init() interface which must be overridden in derivatives
+    virtual int init() noexcept = 0;
+
+    //! refresh() interface which must be overridden in derivatives
+    virtual int refresh() noexcept = 0;
+
+    //! end() interface which must be overridden in derivatives
+    virtual int end() noexcept = 0;
+};
+
+}; // namespace tasker::tui
+
+#endif /* SRC_TUI_OBJECT_HPP */

--- a/src/tui/window.hpp
+++ b/src/tui/window.hpp
@@ -1,0 +1,99 @@
+#ifndef SRC_TUI_WINDOW_HPP
+#define SRC_TUI_WINDOW_HPP
+
+#include "errors.hpp"
+#include "ncurses.hpp"
+#include "object.hpp"
+#include "utility.hpp"
+#include <memory>
+
+namespace tasker::tui
+{
+
+template <typename CI>
+class basic_window : public object
+{
+protected:
+    CI *ncurses = nullptr;
+    WINDOW *m_win = nullptr;
+
+public:
+    basic_window() = default;
+
+    basic_window(CI &ncurses)
+        : ncurses(&ncurses)
+    {
+    }
+
+    // Defaulted move/copy constructors and assignments
+    basic_window(basic_window &&p) noexcept = default;
+    basic_window &operator=(basic_window &&p) noexcept = default;
+    basic_window(const basic_window &p) noexcept = default;
+    basic_window &operator=(const basic_window &p) noexcept = default;
+
+    // Defaulted destructor override.
+    virtual ~basic_window() noexcept = default;
+
+    // Utility functions
+    operator bool() const noexcept
+    {
+        return m_win != nullptr;
+    }
+
+    WINDOW *handle() const noexcept
+    {
+        return m_win;
+    }
+};
+
+template <typename CI>
+class root_window : public basic_window<CI>
+{
+public:
+    using basic_window<CI>::basic_window;
+
+    // Defaulted destructor override.
+    ~root_window() noexcept
+    {
+        end();
+    }
+
+    int init() noexcept final override
+    {
+        if (!this->ncurses) {
+            return error(ERROR, "root_window::ncurses was null during init()");
+        }
+
+        this->m_win = this->ncurses->initscr();
+        if (this->m_win == nullptr) {
+            return error(ERROR_INITSCR, "initscr() returned a nullptr");
+        }
+
+        return OK;
+    }
+
+    // Virtual overrides
+    int refresh() noexcept final override
+    {
+        if (!*this) {
+            return error(ERR,
+                         "root_window::refresh() called on a null handle");
+        }
+
+        return this->ncurses->refresh();
+    }
+
+    int end() noexcept final override
+    {
+        if (this->m_win) {
+            auto rc = this->ncurses->endwin();
+            this->m_win = nullptr;
+            return rc;
+        }
+        return ERR;
+    }
+};
+
+}; // namespace tasker::tui
+
+#endif /* SRC_TUI_WINDOW_HPP */


### PR DESCRIPTION
This commit brings in the following classes:
    - tasker::tui::object
        - Virtualized base function interfaces; these must be
          implemented in any derivatives using `object` as a base
            - `int init() noexcept`
            - `int refresh() noexcept`
            - `int end() noexcept`
    - tasker::tui::basic_window<CI> : public object
    - tasker::tui::root_window<CI> : public basic_window<CI>

This decouples the root window's logic out of the `tasker::tui::tui`
class into a single-purpose `root_window<CI>` object.

Def'n(object):
    A pure virtual base class. It holds a default virtual destructor,
    as well as three pure virtual functions which should be overridden
    in any derivative which make use of them: `int init() noexcept`,
    `int refresh() noexcept` and `int end() noexcept`.

Def'n(basic_window<CI> : public object):
    A base window (WINDOW *) container. This base class itself has no
    ability to set or modify its internal `WINDOW *m_win`, but provides
    the member as a protected variable to be used by derivatives.

Def'n(root_window<CI> : public basic_window<CI>):
    A root window (stdscr) container. Its responsibility involves the
    creation, updating (refreshing) and ending of a root window. There
    should only be one true instance of this class in any one TUI
    program, as there should only ever be one root window.

Now, `tui` maintains a `root_window<CI>` member in place of its previous
direct ownership of a `WINDOW *`.

Signed-off-by: Kevin Morris <kevr@0cost.org>