### PR TITLE
feat: add tui::pane<CI>, a window switch

### DIFF
--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -88,3 +88,10 @@ logging_test = executable(
   dependencies : test_deps,
 )
 test('logging test', logging_test)
+
+pane_test = executable(
+  'pane.test',
+  'pane.test.cpp',
+  dependencies : test_deps,
+)
+test('pane test', pane_test)

--- a/src/tests/pane.test.cpp
+++ b/src/tests/pane.test.cpp
@@ -1,0 +1,96 @@
+#include "tui/pane.hpp"
+#include "mocks/ncurses.hpp"
+#include "tui/root_window.hpp"
+#include <gtest/gtest.h>
+using namespace tasker;
+
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Return;
+
+class pane_test : public ::testing::Test
+{
+protected:
+    ext::mock_ncurses ncurses;
+
+    using root_window_t = tui::root_window<ext::ncurses>;
+    std::shared_ptr<root_window_t> root;
+
+    using window_t = tui::window<ext::ncurses>;
+
+    using pane_t = tui::pane<ext::ncurses>;
+    std::shared_ptr<pane_t> m_pane;
+
+    // Metadata
+    WINDOW win_root;
+    WINDOW win_pane;
+
+public:
+    virtual void SetUp() override
+    {
+        EXPECT_CALL(ncurses, initscr()).WillOnce(Return(&win_root));
+        EXPECT_CALL(ncurses, endwin()).WillOnce(Return(OK));
+
+        EXPECT_CALL(ncurses, get_max_yx(_, _, _))
+            .WillRepeatedly(Invoke([](WINDOW *, int &y, int &x) {
+                x = 800;
+                y = 600;
+            }));
+        EXPECT_CALL(ncurses, subwin(_, _, _, _, _))
+            .WillOnce(Return(&win_pane));
+        EXPECT_CALL(ncurses, delwin(_)).WillRepeatedly(Return(OK));
+
+        root = std::make_shared<root_window_t>(ncurses);
+        ASSERT_EQ(root->init(), OK);
+
+        m_pane = std::make_shared<pane_t>(ncurses, root);
+        ASSERT_EQ(m_pane->init(), OK);
+    }
+
+    virtual void TearDown() override
+    {
+        m_pane->end();
+        root->end();
+    }
+};
+
+TEST_F(pane_test, refresh_error)
+{
+    EXPECT_CALL(ncurses, wrefresh(_)).WillOnce(Return(ERR));
+    ASSERT_EQ(m_pane->refresh(), ERR);
+}
+
+TEST_F(pane_test, focus_on_empty_children)
+{
+    ASSERT_THROW(m_pane->focus(0), std::out_of_range);
+}
+
+TEST_F(pane_test, focus_out_of_range)
+{
+    WINDOW win_pane_child;
+    EXPECT_CALL(ncurses, subwin(_, _, _, _, _))
+        .WillOnce(Return(&win_pane_child));
+
+    auto window = std::make_shared<window_t>(ncurses, m_pane);
+    ASSERT_EQ(window->init(), OK);
+
+    // We only have one child; focusing on i=1 should overflow.
+    ASSERT_THROW(m_pane->focus(1), std::out_of_range);
+}
+
+TEST_F(pane_test, focus_refresh_error)
+{
+    WINDOW win_pane_child;
+    EXPECT_CALL(ncurses, subwin(_, _, _, _, _))
+        .WillOnce(Return(&win_pane_child));
+
+    auto window = std::make_shared<window_t>(ncurses, m_pane);
+    ASSERT_EQ(window->init(), OK);
+
+    m_pane->focus(0);
+    EXPECT_CALL(ncurses, wrefresh(_))
+        .Times(2)
+        .WillOnce(Return(OK))
+        .WillOnce(Return(ERR));
+    ASSERT_EQ(m_pane->refresh(), ERR);
+}

--- a/src/tests/tui.test.cpp
+++ b/src/tests/tui.test.cpp
@@ -4,7 +4,30 @@
 using namespace tasker;
 
 using ::testing::_;
+using ::testing::Invoke;
 using ::testing::Return;
+
+template <typename CI>
+void expect_root(CI &ncurses, WINDOW *win)
+{
+    EXPECT_CALL(ncurses, initscr()).WillOnce(Return(win));
+    EXPECT_CALL(ncurses, keypad(_, _)).WillOnce(Return(OK));
+    EXPECT_CALL(ncurses, raw()).WillOnce(Return(OK));
+    EXPECT_CALL(ncurses, noecho()).WillOnce(Return(OK));
+    EXPECT_CALL(ncurses, endwin()).WillOnce(Return(OK));
+    EXPECT_CALL(ncurses, get_max_yx(_, _, _))
+        .WillOnce(Invoke([](WINDOW *, int &y, int &x) {
+            x = 800;
+            y = 600;
+        }));
+}
+
+template <typename CI>
+void expect_pane(CI &ncurses, WINDOW *win)
+{
+    EXPECT_CALL(ncurses, subwin(_, _, _, _, _)).WillOnce(Return(win));
+    EXPECT_CALL(ncurses, delwin(_)).WillOnce(Return(OK));
+}
 
 class tui_test : public ::testing::Test
 {
@@ -17,6 +40,7 @@ class mock_tui_test : public ::testing::Test
 {
 protected:
     WINDOW mock_win;
+    WINDOW mock_pane;
 
     ext::mock_ncurses ncurses;
     tui::tui<ext::ncurses> term { ncurses };
@@ -24,11 +48,8 @@ protected:
 public:
     virtual void SetUp() override
     {
-        EXPECT_CALL(ncurses, initscr()).WillOnce(Return(&mock_win));
-        EXPECT_CALL(ncurses, keypad(_, _)).WillOnce(Return(OK));
-        EXPECT_CALL(ncurses, raw()).WillOnce(Return(OK));
-        EXPECT_CALL(ncurses, noecho()).WillOnce(Return(OK));
-        EXPECT_CALL(ncurses, endwin()).WillOnce(Return(OK));
+        expect_root(ncurses, &mock_win);
+        expect_pane(ncurses, &mock_pane);
     }
 };
 
@@ -58,4 +79,16 @@ TEST_F(mock_tui_test, end_twice_noop)
     // End again, expect the same return code since we hit
     // the noop path like we did at the beginning of this test.
     ASSERT_EQ(term.end(), rc);
+}
+
+TEST(tui, pane_init_fails)
+{
+    WINDOW win_root;
+
+    ext::mock_ncurses ncurses;
+    expect_root(ncurses, &win_root);
+    EXPECT_CALL(ncurses, subwin(_, _, _, _, _)).WillOnce(Return(nullptr));
+
+    tui::tui<ext::ncurses> term(ncurses);
+    ASSERT_FALSE(term.init());
 }

--- a/src/tui/basic_window.hpp
+++ b/src/tui/basic_window.hpp
@@ -4,8 +4,8 @@
 #include "../ncurses.hpp"
 #include "object.hpp"
 #include <algorithm>
-#include <list>
 #include <memory>
+#include <vector>
 
 namespace tasker::tui
 {
@@ -32,7 +32,7 @@ protected:
 
     using basic_window_ptr = std::shared_ptr<basic_window<CI>>;
 
-    std::list<basic_window_ptr> m_children;
+    std::vector<basic_window_ptr> m_children;
 
     // Dimensions
     int m_x { 0 };

--- a/src/tui/pane.hpp
+++ b/src/tui/pane.hpp
@@ -1,0 +1,62 @@
+#ifndef SRC_TUI_PANE_HPP
+#define SRC_TUI_PANE_HPP
+
+#include "window.hpp"
+#include <fmt/format.h>
+#include <stdexcept>
+#include <vector>
+
+namespace tasker::tui
+{
+
+template <typename CI>
+class pane : public window<CI>
+{
+private:
+    size_t m_i = 0;
+
+public:
+    using window<CI>::window;
+
+    ~pane() = default;
+
+    void focus(size_t i)
+    {
+        auto size = this->m_children.size();
+        auto n = size - 1;
+        if (!size) {
+            throw std::out_of_range("pane::m_children is empty");
+        } else if (i > n) {
+            auto message = fmt::format("provided i={0} is out of bounds, "
+                                       "there are {1} children ({2}-{3})",
+                                       i,
+                                       size,
+                                       0,
+                                       n);
+            throw std::out_of_range(message);
+        }
+
+        m_i = i;
+    }
+
+    int refresh() noexcept final override
+    {
+        if (auto rc = window<CI>::refresh()) {
+            return rc;
+        }
+
+        if (this->m_children.size()) {
+            if (auto rc = this->m_children[m_i]->refresh()) {
+                return rc;
+            }
+        }
+
+        return OK;
+    }
+
+    int refresh_all() noexcept = delete;
+};
+
+}; // namespace tasker::tui
+
+#endif /* SRC_TUI_PANE_HPP */

--- a/src/tui/window.hpp
+++ b/src/tui/window.hpp
@@ -51,7 +51,7 @@ public:
         return std::make_tuple(m_x_offset, m_y_offset);
     }
 
-    int init() noexcept final override
+    int init() noexcept override
     {
         if (!this->ncurses) {
             return error(ERROR, "window::ncurses was null during init()");
@@ -67,7 +67,7 @@ public:
         return OK;
     }
 
-    int refresh() noexcept final override
+    int refresh() noexcept override
     {
         if (!*this) {
             return error(ERR, "window::refresh() called on a null handle");
@@ -76,7 +76,7 @@ public:
         return this->ncurses->wrefresh(this->m_win);
     }
 
-    int end() noexcept final override
+    int end() noexcept override
     {
         if (this->m_win) {
             auto rc = this->ncurses->delwin(this->m_win);


### PR DESCRIPTION
This class is meant to implement a window switch feature,
which uses itself (a window) as the parent of a particular
window being focused.

- `pane::focus(size_t i)` changes focus to an indice of a child
- a `window<CI>` becomes a child of another with `window::init()`

Signed-off-by: Kevin Morris <kevr@0cost.org>