### PR TITLE
feat: add input loop to the program

### DIFF
--- a/src/callback.hpp
+++ b/src/callback.hpp
@@ -1,0 +1,36 @@
+#ifndef SRC_CALLBACK_HPP
+#define SRC_CALLBACK_HPP
+
+#include <functional>
+#include <map>
+
+namespace tasker
+{
+
+template <typename T>
+class callback
+{
+private:
+    using function_t = std::function<void()>;
+    std::map<T, function_t> table;
+
+public:
+    function_t &operator[](const T &key)
+    {
+        return table[key];
+    }
+
+    bool exists(const T &key) const
+    {
+        return table.find(key) != table.end();
+    }
+
+    void call(const T &key) const
+    {
+        return table.at(key)();
+    }
+};
+
+}; // namespace tasker
+
+#endif /* SRC_CALLBACK_HPP */

--- a/src/config/keybinds.cpp
+++ b/src/config/keybinds.cpp
@@ -7,5 +7,6 @@ cfg::config &cfg::add_keybind_options(cfg::config &conf)
     conf.option("key_quit",
                 po::value<char>()->default_value(default_keybinds::KEY_QUIT),
                 "quit keybind");
+
     return conf;
 }

--- a/src/config/keybinds.cpp
+++ b/src/config/keybinds.cpp
@@ -1,0 +1,11 @@
+#include "keybinds.hpp"
+using namespace tasker;
+namespace po = boost::program_options;
+
+cfg::config &cfg::add_keybind_options(cfg::config &conf)
+{
+    conf.option("key_quit",
+                po::value<char>()->default_value(default_keybinds::KEY_QUIT),
+                "quit keybind");
+    return conf;
+}

--- a/src/config/keybinds.hpp
+++ b/src/config/keybinds.hpp
@@ -2,6 +2,7 @@
 #define SRC_CONFIG_KEYBINDS_HPP
 
 #include "config.hpp"
+#include "context.hpp"
 
 namespace tasker::cfg
 {

--- a/src/config/keybinds.hpp
+++ b/src/config/keybinds.hpp
@@ -1,0 +1,17 @@
+#ifndef SRC_CONFIG_KEYBINDS_HPP
+#define SRC_CONFIG_KEYBINDS_HPP
+
+#include "config.hpp"
+
+namespace tasker::cfg
+{
+
+enum default_keybinds : int {
+    KEY_QUIT = 'q',
+};
+
+cfg::config &add_keybind_options(cfg::config &conf);
+
+}; // namespace tasker::cfg
+
+#endif /* SRC_CONFIG_KEYBINDS_HPP */

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -1,0 +1,42 @@
+#ifndef SRC_CONTEXT_HPP
+#define SRC_CONTEXT_HPP
+
+#include "callback.hpp"
+
+namespace tasker
+{
+
+template <typename T>
+class context
+{
+public:
+    bool running = true;
+    callback<T> keybinds;
+
+    bool keybind_exists(const T &key) const
+    {
+        return keybinds.exists(key);
+    }
+
+    void call_keybind(const T &key) const
+    {
+        return keybinds.call(key);
+    }
+
+    operator bool() const
+    {
+        return running;
+    }
+
+    template <typename Config>
+    static void bind_keys(context<T> &ctx, Config &conf)
+    {
+        ctx.keybinds[conf.template get<char>("key_quit")] = [&ctx] {
+            ctx.running = false;
+        };
+    }
+};
+
+}; // namespace tasker
+
+#endif /* SRC_CONTEXT_HPP */

--- a/src/errors.hpp
+++ b/src/errors.hpp
@@ -12,6 +12,7 @@ enum tasker_error : int {
     ERROR_ECHO = 4,
     ERROR_SUBWIN = 5,
     ERROR_GETMAXYX = 6,
+    ERROR_WADDSTR = 7,
 };
 
 #endif /* SRC_ERRORS_HPP */

--- a/src/ext/ncurses.cpp
+++ b/src/ext/ncurses.cpp
@@ -68,6 +68,11 @@ int ext::ncurses::delwin(WINDOW *win) noexcept
     return ::delwin(win);
 }
 
+int ext::ncurses::w_add_str(WINDOW *win, const char *str) noexcept
+{
+    return waddstr(win, str);
+}
+
 WINDOW *ext::ncurses::root() noexcept
 {
     return m_root;

--- a/src/ext/ncurses.cpp
+++ b/src/ext/ncurses.cpp
@@ -32,6 +32,11 @@ int ext::ncurses::noecho() noexcept
     return ::noecho();
 }
 
+int ext::ncurses::getchar() noexcept
+{
+    return getch();
+}
+
 int ext::ncurses::refresh() noexcept
 {
     return ::refresh();

--- a/src/ext/ncurses.hpp
+++ b/src/ext/ncurses.hpp
@@ -27,6 +27,9 @@ public:
     void get_max_yx(WINDOW *, int &, int &) noexcept;
     int delwin(WINDOW *) noexcept;
 
+    // Window utility functions
+    int w_add_str(WINDOW *, const char *) noexcept;
+
 public:
     WINDOW *root() noexcept;
 };

--- a/src/ext/ncurses.hpp
+++ b/src/ext/ncurses.hpp
@@ -17,6 +17,7 @@ public:
     int keypad(WINDOW *, bool) noexcept;
     int raw() noexcept;
     int noecho() noexcept;
+    int getchar() noexcept;
     int refresh() noexcept;
     int wrefresh(WINDOW *) noexcept;
     int endwin() noexcept;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,9 +4,11 @@
  * Copyright (C) 2022 Kevin Morris <kevr@0cost.org>
  * All Rights Reserved.
  **/
+#include "callback.hpp"
 #include "config.hpp"
 #include "config/config.hpp"
 #include "config/keybinds.hpp"
+#include "context.hpp"
 #include "env.hpp"
 #include "logging.hpp"
 #include "ncurses.hpp"
@@ -77,11 +79,14 @@ int tasker_main(ext::ncurses &ncurses, int argc, char *argv[])
     // Refresh the TUI
     term.refresh();
 
+    tasker::context<int> ctx;
+    ctx.bind_keys(ctx, conf);
+
     // TUI input logic, wait-state until quit key is pressed
-    const int key_quit = conf.get<char>("key_quit");
-    while (int ch = ncurses.getchar()) {
-        if (ch == key_quit) {
-            break;
+    int ch;
+    while (ctx && (ch = ncurses.getchar())) {
+        if (ctx.keybind_exists(ch)) {
+            ctx.call_keybind(ch);
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,7 +77,13 @@ int tasker_main(ext::ncurses &ncurses, int argc, char *argv[])
     // Refresh the TUI
     term.refresh();
 
-    // TODO: TUI input logic, wait-state until quit key
+    // TUI input logic, wait-state until quit key is pressed
+    const int key_quit = conf.get<char>("key_quit");
+    while (int ch = ncurses.getchar()) {
+        if (ch == key_quit) {
+            break;
+        }
+    }
 
     // Restore logger pointer and close any open file stream
     logger::reset();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
  **/
 #include "config.hpp"
 #include "config/config.hpp"
+#include "config/keybinds.hpp"
 #include "env.hpp"
 #include "logging.hpp"
 #include "ncurses.hpp"
@@ -27,6 +28,8 @@ int tasker_main(ext::ncurses &ncurses, int argc, char *argv[])
     conf.option("logfile,l",
                 po::value<std::string>(),
                 "designate a log file instead of stderr");
+
+    cfg::add_keybind_options(conf);
 
     conf.parse_args(argc, argv);
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -5,20 +5,25 @@ configure_file(
   configuration : conf
 )
 
+tasker_sources = [
+  'projects/project.cpp',
+  'tasks/task.cpp',
+  'users/user.cpp',
+  'config/config.cpp',
+  'env.cpp',
+  'utility.cpp',
+  'logging.cpp',
+]
+
 build_tests = get_option('build_tests')
 
 if build_tests
   tasker_test_lib = static_library(
     'tasker_test',
-    'projects/project.cpp',
-    'tasks/task.cpp',
-    'users/user.cpp',
-    'config/config.cpp',
-    'env.cpp',
-    'utility.cpp',
-    'logging.cpp',
-
-    'testing.cpp',
+    [
+      tasker_sources,
+      'testing.cpp',
+    ],
     cpp_args : '-DTESTING',
     include_directories : [inc, fmt_inc],
   )
@@ -48,13 +53,7 @@ build_bin = get_option('build_bin')
 if build_bin
   tasker_lib = static_library(
     'tasker',
-    'projects/project.cpp',
-    'tasks/task.cpp',
-    'users/user.cpp',
-    'config/config.cpp',
-    'env.cpp',
-    'utility.cpp',
-    'logging.cpp',
+    tasker_sources,
     include_directories : [inc, fmt_inc],
   )
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,6 +9,7 @@ tasker_sources = [
   'projects/project.cpp',
   'tasks/task.cpp',
   'users/user.cpp',
+  'config/keybinds.cpp',
   'config/config.cpp',
   'env.cpp',
   'utility.cpp',

--- a/src/mocks/ncurses.hpp
+++ b/src/mocks/ncurses.hpp
@@ -22,6 +22,8 @@ public:
     MOCK_METHOD(WINDOW *, subwin, (WINDOW *, int, int, int, int),
                 (noexcept, override));
     MOCK_METHOD(int, delwin, (WINDOW *), (noexcept, override));
+    MOCK_METHOD(int, w_add_str, (WINDOW *, const char *),
+                (noexcept, override));
 };
 
 }; // namespace tasker::ext

--- a/src/stubs/ncurses.cpp
+++ b/src/stubs/ncurses.cpp
@@ -89,6 +89,11 @@ int ext::ncurses::delwin(WINDOW *win) noexcept
     return OK;
 }
 
+int ext::ncurses::w_add_str(WINDOW *, const char *) noexcept
+{
+    return OK;
+}
+
 // Public utility functions
 const WINDOW *ext::ncurses::root() const noexcept
 {

--- a/src/stubs/ncurses.cpp
+++ b/src/stubs/ncurses.cpp
@@ -3,6 +3,7 @@
  * All Rights Reserved.
  **/
 #include "ncurses.hpp"
+#include "config/keybinds.hpp"
 using namespace tasker;
 
 // Static member initialization
@@ -39,6 +40,11 @@ int ext::ncurses::raw() noexcept
 int ext::ncurses::noecho() noexcept
 {
     return OK;
+}
+
+int ext::ncurses::getchar() noexcept
+{
+    return cfg::default_keybinds::KEY_QUIT;
 }
 
 int ext::ncurses::wrefresh(WINDOW *) noexcept

--- a/src/stubs/ncurses.hpp
+++ b/src/stubs/ncurses.hpp
@@ -45,6 +45,9 @@ public:
     virtual void get_max_yx(WINDOW *, int &, int &) noexcept;
     virtual int delwin(WINDOW *) noexcept;
 
+    // Window utility functions
+    virtual int w_add_str(WINDOW *, const char *) noexcept;
+
 public:
     // Test utilities.
     const WINDOW *root() const noexcept;

--- a/src/stubs/ncurses.hpp
+++ b/src/stubs/ncurses.hpp
@@ -35,6 +35,7 @@ public:
     virtual int keypad(WINDOW *, bool) noexcept;
     virtual int raw() noexcept;
     virtual int noecho() noexcept;
+    virtual int getchar() noexcept;
     virtual int wrefresh(WINDOW *) noexcept;
     virtual int refresh() noexcept;
     virtual int endwin() noexcept;


### PR DESCRIPTION
```
commit 0980ee86f8786989182ee49084a4e20b5dd6ca9b
    feat: add waddstr wrapper `w_add_str`

    Make use of the new w_add_str ncurses function by
    adding a string detailing the quit keybind to the
    pane window within `tasker::tui::tui`.

    Signed-off-by: Kevin Morris <kevr@0cost.org>

commit 004c2b82831440a24ae136ea727353d828fb04c0
Author: Kevin Morris <kevr@0cost.org>
Date:   Mon Aug 29 22:26:50 2022 -0700

    feat: add tasker::context<T>

    A `tasker::context` contains a `running` flag and a
    `callback<T> keybinds` table.

    The new `tasker::cfg::bind_keybinds(context<T>& ctx, cfg::config& conf)`
    function sets up base `context` keybinds corresponding to runtime
    config `conf`.

    This can be used to deal with keybinds

    Signed-off-by: Kevin Morris <kevr@0cost.org>

commit a99171f24fca74ccf1e201affc6169db34bfeb49
Author: Kevin Morris <kevr@0cost.org>
Date:   Mon Aug 29 21:44:48 2022 -0700

    feat: add input loop to the program

    The config option 'key_quit' is used to determine which key
    pressed should cause the program to end.

    Signed-off-by: Kevin Morris <kevr@0cost.org>

commit 630d4f6565bdd7962e6af0ec4204746e88ceffe2
Author: Kevin Morris <kevr@0cost.org>
Date:   Mon Aug 29 21:26:23 2022 -0700

    feat: add_keybind_options(cfg::config&)

    A function used to add keybind options to cfg::config,
    defaulted using the cfg::default_keybinds enum.

    Signed-off-by: Kevin Morris <kevr@0cost.org>
```