### PR TITLE
debug logging & window padding

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -2,6 +2,7 @@
 using namespace tasker;
 
 std::ostream *logger::out = &std::cout;
+bool logger::debug_enabled = false;
 
 std::ostream &logger::stream(std::ostream &os)
 {
@@ -14,35 +15,33 @@ void logger::reset()
     out = &std::cout;
 }
 
-void logger::p_info(const std::string &line)
+void logger::set_debug(bool enabled)
+{
+    debug_enabled = enabled;
+}
+
+void logger::info(const std::string &line)
 {
     auto output = fmt::format("[INFO] {0}\n", line);
     *out << output;
 }
 
-void logger::p_error(const std::string &line)
+void logger::error(const std::string &line)
 {
     auto output = fmt::format("[ERROR] {0}\n", line);
     *out << output;
 }
 
-void logger::p_warning(const std::string &line)
+void logger::warning(const std::string &line)
 {
     auto output = fmt::format("[WARN] {0}\n", line);
     *out << output;
 }
 
-void logger::info(const std::string &msg)
+void logger::debug(const std::string &line)
 {
-    p_info(msg);
-}
-
-void logger::error(const std::string &msg)
-{
-    p_error(msg);
-}
-
-void logger::warning(const std::string &msg)
-{
-    p_warning(msg);
+    if (debug_enabled) {
+        auto output = fmt::format("[DEBUG] {0}\n", line);
+        *out << output;
+    }
 }

--- a/src/logging.hpp
+++ b/src/logging.hpp
@@ -11,19 +11,17 @@ class logger
 {
 private:
     static std::ostream *out;
-
-private:
-    void p_info(const std::string &line);
-    void p_error(const std::string &line);
-    void p_warning(const std::string &line);
+    static bool debug_enabled;
 
 public:
     static std::ostream &stream(std::ostream &os);
     static void reset();
+    static void set_debug(bool enabled);
 
-    void info(const std::string &msg);
-    void error(const std::string &msg);
-    void warning(const std::string &msg);
+    void info(const std::string &line);
+    void error(const std::string &line);
+    void warning(const std::string &line);
+    void debug(const std::string &line);
 };
 
 }; // namespace tasker

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@ int tasker_main(ext::ncurses &ncurses, int argc, char *argv[])
     // Parse command line arguments and handle them.
     auto &conf = cfg::config::ref();
     namespace po = boost::program_options;
+    conf.option("debug,d", "enable debug logging");
     conf.option("logfile,l",
                 po::value<std::string>(),
                 "designate a log file instead of stderr");
@@ -62,6 +63,10 @@ int tasker_main(ext::ncurses &ncurses, int argc, char *argv[])
                       << path.value().string() << std::endl;
             return ERR;
         }
+    }
+
+    if (conf.exists("debug")) {
+        logger::set_debug(true);
     }
 
     if (conf.exists("logfile")) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,7 +71,11 @@ int tasker_main(ext::ncurses &ncurses, int argc, char *argv[])
 
     if (conf.exists("logfile")) {
         auto logfile = conf["logfile"];
-        ofs.open(logfile.c_str(), std::ios::out);
+        ofs.open(logfile.c_str(), std::ios::out | std::ios::app);
+        logger::stream(ofs);
+    } else {
+        // Use default log file 'tasker.log'
+        ofs.open("tasker.log", std::ios::out | std::ios::app);
         logger::stream(ofs);
     }
 

--- a/src/tests/logging.test.cpp
+++ b/src/tests/logging.test.cpp
@@ -36,3 +36,11 @@ TEST_F(logging_test, error)
     logger.error("Test");
     ASSERT_EQ(ss.str(), "[ERROR] Test\n");
 }
+
+TEST_F(logging_test, debug)
+{
+    tasker::logger::set_debug(true);
+    logger.debug("Test");
+    ASSERT_EQ(ss.str(), "[DEBUG] Test\n");
+    tasker::logger::set_debug(false);
+}

--- a/src/tests/main.test.cpp
+++ b/src/tests/main.test.cpp
@@ -14,13 +14,12 @@ using ::testing::Return;
 class main_test : public ::testing::Test
 {
 protected:
-    std::string tmpdir;
+    std::filesystem::path tmpdir;
 
 protected:
     void write_config(const std::map<std::string, std::string> &options)
     {
-        std::filesystem::path p(tmpdir);
-        p /= "config";
+        std::filesystem::path p = tmpdir / "config";
         {
             std::ofstream ofs(p.c_str(), std::ios::out);
             for (auto &kv : options) {
@@ -237,4 +236,27 @@ TEST_F(main_test, logfile)
     std::string output;
     std::getline(ifs, output);
     ASSERT_EQ(output, "[INFO] starting tui...");
+}
+
+TEST_F(main_test, enable_debug_logging)
+{
+    const auto logpath = tmpdir / "tasker.log";
+    const char *_argv[] = {
+        PROG.c_str(), "--debug", "--logfile", logpath.c_str(), nullptr
+    };
+    auto argv = const_cast<char **>(_argv);
+    int argc = 4;
+
+    auto rc = main_real(argc, argv);
+    ASSERT_EQ(rc, OK);
+
+    std::ifstream ifs(logpath.c_str());
+    std::string line;
+    std::string content;
+    while (std::getline(ifs, line)) {
+        content += line;
+        content.push_back('\n');
+    }
+
+    ASSERT_NE(content.find("[DEBUG]"), std::string::npos);
 }

--- a/src/tui.hpp
+++ b/src/tui.hpp
@@ -82,6 +82,8 @@ public:
             return *this;
         }
 
+        m_pane->inherit();  // Update sizes relative to the root
+        m_pane->padding(1); // Set a padding of 1
         if (auto rc = m_pane->init()) {
             m_return_code = error(rc, "m_pane->init() failed: ", rc);
             return *this;


### PR DESCRIPTION
```
commit 35319c7001f6fca8ed107ae13afdd631a985a64c (HEAD -> debug-padding, origin/debug-padding, master)
Author: Kevin Morris <kevr@0cost.org>
Date:   Tue Aug 30 01:00:33 2022 -0700

    feat: add padding configurable to window

    Signed-off-by: Kevin Morris <kevr@0cost.org>

commit d71e913969cf945fa05b440b7f78602065defe02
Author: Kevin Morris <kevr@0cost.org>
Date:   Tue Aug 30 00:39:52 2022 -0700

    fix: default logger output to './tasker.log'

    Signed-off-by: Kevin Morris <kevr@0cost.org>

commit 2739d0150bbab7f351ecf2ea8950c9ae65ca433e
Author: Kevin Morris <kevr@0cost.org>
Date:   Tue Aug 30 00:39:27 2022 -0700

    feat: add debug logging (--debug, -d)

    Signed-off-by: Kevin Morris <kevr@0cost.org>
```