### PR TITLE
tui::project<CI>

### DIFF
--- a/src/errors.hpp
+++ b/src/errors.hpp
@@ -10,7 +10,7 @@ enum tasker_error : int {
     ERROR_KEYPAD = 2,
     ERROR_RAW = 3,
     ERROR_ECHO = 4,
-    ERROR_SUBWIN = 5,
+    ERROR_DERWIN = 5,
     ERROR_GETMAXYX = 6,
     ERROR_WADDSTR = 7,
 };

--- a/src/ext/ncurses.cpp
+++ b/src/ext/ncurses.cpp
@@ -52,10 +52,10 @@ int ext::ncurses::endwin() noexcept
     return ::endwin();
 }
 
-WINDOW *ext::ncurses::subwin(WINDOW *parent, int nlines, int ncols,
+WINDOW *ext::ncurses::derwin(WINDOW *parent, int nlines, int ncols,
                              int begin_y, int begin_x) noexcept
 {
-    return ::subwin(parent, nlines, ncols, begin_y, begin_x);
+    return ::derwin(parent, nlines, ncols, begin_y, begin_x);
 }
 
 void ext::ncurses::get_max_yx(WINDOW *win, int &y, int &x) noexcept

--- a/src/ext/ncurses.hpp
+++ b/src/ext/ncurses.hpp
@@ -23,7 +23,7 @@ public:
     int endwin() noexcept;
 
     // Child window functions
-    WINDOW *subwin(WINDOW *, int, int, int, int) noexcept;
+    WINDOW *derwin(WINDOW *, int, int, int, int) noexcept;
     void get_max_yx(WINDOW *, int &, int &) noexcept;
     int delwin(WINDOW *) noexcept;
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -20,25 +20,25 @@ void logger::set_debug(bool enabled)
     debug_enabled = enabled;
 }
 
-void logger::info(const std::string &line)
+void logger::info(const std::string &line) const
 {
     auto output = fmt::format("[INFO] {0}\n", line);
     *out << output;
 }
 
-void logger::error(const std::string &line)
+void logger::error(const std::string &line) const
 {
     auto output = fmt::format("[ERROR] {0}\n", line);
     *out << output;
 }
 
-void logger::warning(const std::string &line)
+void logger::warning(const std::string &line) const
 {
     auto output = fmt::format("[WARN] {0}\n", line);
     *out << output;
 }
 
-void logger::debug(const std::string &line)
+void logger::debug(const std::string &line) const
 {
     if (debug_enabled) {
         auto output = fmt::format("[DEBUG] {0}\n", line);

--- a/src/logging.hpp
+++ b/src/logging.hpp
@@ -18,10 +18,10 @@ public:
     static void reset();
     static void set_debug(bool enabled);
 
-    void info(const std::string &line);
-    void error(const std::string &line);
-    void warning(const std::string &line);
-    void debug(const std::string &line);
+    void info(const std::string &line) const;
+    void error(const std::string &line) const;
+    void warning(const std::string &line) const;
+    void debug(const std::string &line) const;
 };
 
 }; // namespace tasker

--- a/src/mocks/ncurses.hpp
+++ b/src/mocks/ncurses.hpp
@@ -19,7 +19,7 @@ public:
     MOCK_METHOD(int, endwin, (), (noexcept, override));
     MOCK_METHOD(void, get_max_yx, (WINDOW *, int &, int &),
                 (noexcept, override));
-    MOCK_METHOD(WINDOW *, subwin, (WINDOW *, int, int, int, int),
+    MOCK_METHOD(WINDOW *, derwin, (WINDOW *, int, int, int, int),
                 (noexcept, override));
     MOCK_METHOD(int, delwin, (WINDOW *), (noexcept, override));
     MOCK_METHOD(int, w_add_str, (WINDOW *, const char *),

--- a/src/projects/project.hpp
+++ b/src/projects/project.hpp
@@ -14,7 +14,7 @@ struct project_data {
 
 class project
 {
-private:
+protected:
     project_data m_data;
 
 public:

--- a/src/stubs/ncurses.cpp
+++ b/src/stubs/ncurses.cpp
@@ -64,7 +64,7 @@ int ext::ncurses::endwin() noexcept
 }
 
 // Child window functions
-WINDOW *ext::ncurses::subwin(WINDOW *parent, int, int, int, int) noexcept
+WINDOW *ext::ncurses::derwin(WINDOW *parent, int, int, int, int) noexcept
 {
     WINDOW *win = new WINDOW;
     m_windows[win] = parent;

--- a/src/stubs/ncurses.hpp
+++ b/src/stubs/ncurses.hpp
@@ -50,7 +50,7 @@ public:
     virtual int endwin() noexcept;
 
     // Child window functions
-    virtual WINDOW *subwin(WINDOW *, int, int, int, int) noexcept;
+    virtual WINDOW *derwin(WINDOW *, int, int, int, int) noexcept;
     virtual void get_max_yx(WINDOW *, int &, int &) noexcept;
     virtual int delwin(WINDOW *) noexcept;
 

--- a/src/tests/pane.test.cpp
+++ b/src/tests/pane.test.cpp
@@ -36,7 +36,7 @@ public:
                 x = 800;
                 y = 600;
             }));
-        EXPECT_CALL(ncurses, subwin(_, _, _, _, _))
+        EXPECT_CALL(ncurses, derwin(_, _, _, _, _))
             .WillOnce(Return(&win_pane));
         EXPECT_CALL(ncurses, delwin(_)).WillRepeatedly(Return(OK));
 
@@ -68,7 +68,7 @@ TEST_F(pane_test, focus_on_empty_children)
 TEST_F(pane_test, focus_out_of_range)
 {
     WINDOW win_pane_child;
-    EXPECT_CALL(ncurses, subwin(_, _, _, _, _))
+    EXPECT_CALL(ncurses, derwin(_, _, _, _, _))
         .WillOnce(Return(&win_pane_child));
 
     auto window = std::make_shared<window_t>(ncurses, m_pane);
@@ -81,7 +81,7 @@ TEST_F(pane_test, focus_out_of_range)
 TEST_F(pane_test, focus_refresh_error)
 {
     WINDOW win_pane_child;
-    EXPECT_CALL(ncurses, subwin(_, _, _, _, _))
+    EXPECT_CALL(ncurses, derwin(_, _, _, _, _))
         .WillOnce(Return(&win_pane_child));
 
     auto window = std::make_shared<window_t>(ncurses, m_pane);

--- a/src/tests/tui.test.cpp
+++ b/src/tests/tui.test.cpp
@@ -29,7 +29,7 @@ void expect_root(CI &ncurses, WINDOW *win)
 template <typename CI>
 void expect_pane(CI &ncurses, WINDOW *win)
 {
-    EXPECT_CALL(ncurses, subwin(_, _, _, _, _)).WillOnce(Return(win));
+    EXPECT_CALL(ncurses, derwin(_, _, _, _, _)).WillRepeatedly(Return(win));
     EXPECT_CALL(ncurses, delwin(_)).WillOnce(Return(OK));
 }
 
@@ -141,7 +141,7 @@ TEST(tui, pane_init_fails)
 
     ext::mock_ncurses ncurses;
     expect_root(ncurses, &win_root);
-    EXPECT_CALL(ncurses, subwin(_, _, _, _, _)).WillOnce(Return(nullptr));
+    EXPECT_CALL(ncurses, derwin(_, _, _, _, _)).WillOnce(Return(nullptr));
 
     tui::tui<ext::ncurses> term(ncurses);
     ASSERT_FALSE(term.init());

--- a/src/tests/tui.test.cpp
+++ b/src/tests/tui.test.cpp
@@ -135,6 +135,16 @@ TEST_F(mock_tui_test, waddstr_fails)
     ASSERT_EQ(term.return_code(), ERROR_WADDSTR);
 }
 
+TEST_F(mock_tui_test, project_init_fails)
+{
+    EXPECT_CALL(ncurses, derwin(_, _, _, _, _))
+        .Times(2)
+        .WillOnce(Return(&mock_pane))
+        .WillOnce(Return(nullptr));
+    term.init();
+    ASSERT_EQ(term.return_code(), ERROR_DERWIN);
+}
+
 TEST(tui, pane_init_fails)
 {
     WINDOW win_root;

--- a/src/tests/window.test.cpp
+++ b/src/tests/window.test.cpp
@@ -100,8 +100,8 @@ TEST_F(mock_window_test, subwin_fails)
     using window_t = tui::window<ext::ncurses>;
     auto window = std::make_shared<window_t>(ncurses, root);
 
-    EXPECT_CALL(ncurses, subwin(_, _, _, _, _)).WillOnce(Return(nullptr));
-    ASSERT_EQ(window->init(), ERROR_SUBWIN);
+    EXPECT_CALL(ncurses, derwin(_, _, _, _, _)).WillOnce(Return(nullptr));
+    ASSERT_EQ(window->init(), ERROR_DERWIN);
 }
 
 TEST_F(mock_window_test, root_refresh_all)
@@ -116,7 +116,7 @@ TEST_F(mock_window_test, root_refresh_all)
     auto window = std::make_shared<window_t>(ncurses, root);
 
     WINDOW child;
-    EXPECT_CALL(ncurses, subwin(_, _, _, _, _)).WillOnce(Return(&child));
+    EXPECT_CALL(ncurses, derwin(_, _, _, _, _)).WillOnce(Return(&child));
     window->init();
 
     EXPECT_CALL(ncurses, wrefresh(_)).WillOnce(Return(OK));
@@ -148,13 +148,13 @@ TEST_F(mock_window_test, refresh_all)
     auto window = std::make_shared<window_t>(ncurses, root);
 
     WINDOW child;
-    EXPECT_CALL(ncurses, subwin(_, _, _, _, _)).WillOnce(Return(&child));
+    EXPECT_CALL(ncurses, derwin(_, _, _, _, _)).WillOnce(Return(&child));
     window->init();
 
     auto leaf = std::make_shared<window_t>(ncurses, window);
 
     WINDOW child2;
-    EXPECT_CALL(ncurses, subwin(_, _, _, _, _)).WillOnce(Return(&child2));
+    EXPECT_CALL(ncurses, derwin(_, _, _, _, _)).WillOnce(Return(&child2));
     leaf->init();
 
     EXPECT_CALL(ncurses, wrefresh(_)).Times(2).WillRepeatedly(Return(OK));

--- a/src/tui/basic_window.hpp
+++ b/src/tui/basic_window.hpp
@@ -38,6 +38,9 @@ protected:
     int m_x { 0 };
     int m_y { 0 };
 
+    // Padding
+    int m_padding { 0 };
+
 public:
     basic_window() = default;
 
@@ -65,6 +68,17 @@ public:
     std::tuple<int, int> dimensions() const
     {
         return std::make_tuple(m_x, m_y);
+    }
+
+    basic_window &padding(int p)
+    {
+        m_padding = p;
+        return *this;
+    }
+
+    int padding() const
+    {
+        return m_padding;
     }
 
     // Utility functions

--- a/src/tui/project.hpp
+++ b/src/tui/project.hpp
@@ -1,0 +1,41 @@
+#ifndef SRC_TUI_PROJECT_HPP
+#define SRC_TUI_PROJECT_HPP
+
+#include "projects/project.hpp"
+#include "window.hpp"
+
+namespace tasker::tui
+{
+
+template <typename CI>
+class project : public window<CI>, public tasker::project
+{
+private:
+    using window_t = window<CI>;
+    using window_ptr = std::shared_ptr<window_t>;
+
+public:
+    using window<CI>::window;
+
+    int id(int id)
+    {
+        this->m_project.id = id;
+        return this->m_project;
+    }
+
+    const std::string &name(const std::string &name)
+    {
+        this->m_project.name = name;
+        return this->m_project.name;
+    }
+
+    const std::string &full_name(const std::string &full_name)
+    {
+        this->m_project.full_name = full_name;
+        return this->m_project.full_name;
+    }
+};
+
+}; // namespace tasker::tui
+
+#endif /* SRC_TUI_PROJECT_HPP */

--- a/src/tui/window.hpp
+++ b/src/tui/window.hpp
@@ -25,9 +25,6 @@ private:
     int m_x_offset { 0 };
     int m_y_offset { 0 };
 
-    // Padding
-    int m_padding { 0 };
-
     // Logging object
     logger logging;
 
@@ -46,9 +43,18 @@ public:
     window &inherit()
     {
         auto [x, y] = m_parent->dimensions();
-        this->m_x = x;
-        this->m_y = y;
+        this->m_x = x - (m_parent->padding() * 2);
+        this->m_y = y - (m_parent->padding() * 2);
         return *this;
+    }
+
+    std::tuple<int, int> dimensions() const
+    {
+        int x = this->m_x - (this->m_padding * 2);
+        int y = this->m_y - (this->m_padding * 2);
+        auto message = fmt::format("dimensions() = ({0}, {1})", x, y);
+        logging.debug(message);
+        return std::make_tuple(x, y);
     }
 
     window &offset(int x_offset, int y_offset)
@@ -63,27 +69,16 @@ public:
         return std::make_tuple(m_x_offset, m_y_offset);
     }
 
-    window &padding(int p)
-    {
-        m_padding = p;
-        return *this;
-    }
-
-    int padding() const
-    {
-        return m_padding;
-    }
-
     int init() noexcept override
     {
         if (!this->ncurses) {
             return error(ERROR, "window::ncurses was null during init()");
         }
 
-        int y = this->m_y - (m_padding * 2);
-        int x = this->m_x - (m_padding * 2);
-        int yo = m_y_offset + m_padding;
-        int xo = m_x_offset + m_padding;
+        int y = this->m_y - (this->m_padding * 2);
+        int x = this->m_x - (this->m_padding * 2);
+        int yo = m_y_offset + this->m_padding;
+        int xo = m_x_offset + this->m_padding;
 
         auto message = fmt::format("derwin({0}, {1}, {2}, {3})", y, x, yo, xo);
         logging.debug(message);

--- a/src/tui/window.hpp
+++ b/src/tui/window.hpp
@@ -85,12 +85,12 @@ public:
         int yo = m_y_offset + m_padding;
         int xo = m_x_offset + m_padding;
 
-        auto message = fmt::format("subwin({0}, {1}, {2}, {3})", y, x, yo, xo);
+        auto message = fmt::format("derwin({0}, {1}, {2}, {3})", y, x, yo, xo);
         logging.debug(message);
 
-        this->m_win = this->ncurses->subwin(m_parent->handle(), y, x, yo, xo);
+        this->m_win = this->ncurses->derwin(m_parent->handle(), y, x, yo, xo);
         if (this->m_win == nullptr) {
-            return error(ERROR_SUBWIN, "subwin() returned a nullptr");
+            return error(ERROR_DERWIN, "derwin() returned a nullptr");
         }
 
         m_parent->add_child(this->shared_from_this());


### PR DESCRIPTION
```
commit ebc86de01fede78cf90d154abc18ea6a0dbd03eb
Author: Kevin Morris <kevr@0cost.org>
Date:   Tue Aug 30 08:51:16 2022 -0700

    feat: add tui::project<CI>
    
    Being a derivative of `tasker::project` and `window<CI>`,
    tui::project<CI> represents a `tasker::project` as a `window<CI>`.
    
    A `tui::project<CI>` is intended to be an overview of a particular
    project, which encapsulates a view of all lists in the project at hand.
    
    Signed-off-by: Kevin Morris <kevr@0cost.org>

commit 1858cabfd83051bcaa0848212a6f1283a29a929d
Author: Kevin Morris <kevr@0cost.org>
Date:   Tue Aug 30 08:49:43 2022 -0700

    fix: move window<CI> padding to basic_window<CI>
    
    We need padding in all basic_window derivatives, including
    root_window. For this reason, padding is moved over to
    basic_window<CI>.
    
    More-so, window::inherit() takes the parent's padding into
    account for derivative window size.
    
    Signed-off-by: Kevin Morris <kevr@0cost.org>

commit a383ef23eacb3c9d32f00b2c0743a9a676521db5
Author: Kevin Morris <kevr@0cost.org>
Date:   Tue Aug 30 08:44:57 2022 -0700

    fix(ncurses): replace subwin with derwin
    
    `derwin` was the original intented function brought in.
    This commit swaps out derwin for subwin in the codebase
    and fixes tests to use/mock it.
    
    Signed-off-by: Kevin Morris <kevr@0cost.org>

commit d4d1746ac9d50f4502cbd9daede4659162483d41
Author: Kevin Morris <kevr@0cost.org>
Date:   Tue Aug 30 08:36:59 2022 -0700

    fix(logging): constify log output functions
    
    Signed-off-by: Kevin Morris <kevr@0cost.org>
```