### PR TITLE
Handle resizing ncurses windows

### DIFF
--- a/src/errors.hpp
+++ b/src/errors.hpp
@@ -13,6 +13,7 @@ enum tasker_error : int {
     ERROR_DERWIN = 5,
     ERROR_GETMAXYX = 6,
     ERROR_WADDSTR = 7,
+    ERROR_NOIMPL = 8,
 };
 
 #endif /* SRC_ERRORS_HPP */

--- a/src/ext/ncurses.cpp
+++ b/src/ext/ncurses.cpp
@@ -80,6 +80,11 @@ int ext::ncurses::wborder(WINDOW *win, chtype ls, chtype rs, chtype ts,
     return ::wborder(win, ls, rs, ts, bs, tl, tr, bl, br);
 }
 
+int ext::ncurses::werase(WINDOW *win) noexcept
+{
+    return ::werase(win);
+}
+
 WINDOW *ext::ncurses::root() noexcept
 {
     return m_root;

--- a/src/ext/ncurses.hpp
+++ b/src/ext/ncurses.hpp
@@ -31,6 +31,7 @@ public:
     int w_add_str(WINDOW *, const char *) noexcept;
     int wborder(WINDOW *, chtype, chtype, chtype, chtype, chtype, chtype,
                 chtype, chtype) noexcept;
+    int werase(WINDOW *) noexcept;
 
 public:
     WINDOW *root() noexcept;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,6 +91,12 @@ int tasker_main(ext::ncurses &ncurses, int argc, char *argv[])
     tasker::context<int> ctx;
     ctx.bind_keys(ctx, conf);
 
+    auto resize = [&term]() {
+        term.resize();
+        term.refresh();
+    };
+    ctx.keybinds[KEY_RESIZE] = resize;
+
     // TUI input logic, wait-state until quit key is pressed
     int ch;
     while (ctx && (ch = ncurses.getchar())) {

--- a/src/mocks/ncurses.hpp
+++ b/src/mocks/ncurses.hpp
@@ -14,6 +14,7 @@ public:
     MOCK_METHOD(int, keypad, (WINDOW *, bool), (noexcept, override));
     MOCK_METHOD(int, raw, (), (noexcept, override));
     MOCK_METHOD(int, noecho, (), (noexcept, override));
+    MOCK_METHOD(int, getchar, (), (noexcept, override));
     MOCK_METHOD(int, wrefresh, (WINDOW *), (noexcept, override));
     MOCK_METHOD(int, refresh, (), (noexcept, override));
     MOCK_METHOD(int, endwin, (), (noexcept, override));
@@ -23,6 +24,10 @@ public:
                 (noexcept, override));
     MOCK_METHOD(int, delwin, (WINDOW *), (noexcept, override));
     MOCK_METHOD(int, w_add_str, (WINDOW *, const char *),
+                (noexcept, override));
+    MOCK_METHOD(int, wborder,
+                (WINDOW *, chtype, chtype, chtype, chtype, chtype, chtype,
+                 chtype, chtype),
                 (noexcept, override));
 };
 

--- a/src/stubs/ncurses.cpp
+++ b/src/stubs/ncurses.cpp
@@ -100,6 +100,11 @@ int ext::ncurses::wborder(WINDOW *, chtype, chtype, chtype, chtype, chtype,
     return OK;
 }
 
+int ext::ncurses::werase(WINDOW *win) noexcept
+{
+    return OK;
+}
+
 // Public utility functions
 const WINDOW *ext::ncurses::root() const noexcept
 {

--- a/src/stubs/ncurses.hpp
+++ b/src/stubs/ncurses.hpp
@@ -22,6 +22,9 @@ using chtype = char;
 #define ACS_LLCORNER '*'
 #define ACS_LRCORNER '*'
 
+// KEY_RESIZE value used in ncurses.h on a Linux x86_64 system
+#define KEY_RESIZE 410
+
 namespace tasker::ext
 {
 

--- a/src/stubs/ncurses.hpp
+++ b/src/stubs/ncurses.hpp
@@ -58,6 +58,7 @@ public:
     virtual int w_add_str(WINDOW *, const char *) noexcept;
     virtual int wborder(WINDOW *, chtype, chtype, chtype, chtype, chtype,
                         chtype, chtype, chtype) noexcept;
+    virtual int werase(WINDOW *) noexcept;
 
 public:
     // Test utilities.

--- a/src/tests/pane.test.cpp
+++ b/src/tests/pane.test.cpp
@@ -37,7 +37,7 @@ public:
                 y = 600;
             }));
         EXPECT_CALL(ncurses, derwin(_, _, _, _, _))
-            .WillOnce(Return(&win_pane));
+            .WillRepeatedly(Return(&win_pane));
         EXPECT_CALL(ncurses, delwin(_)).WillRepeatedly(Return(OK));
 
         root = std::make_shared<root_window_t>(ncurses);

--- a/src/tests/tui.test.cpp
+++ b/src/tests/tui.test.cpp
@@ -31,6 +31,9 @@ void expect_pane(CI &ncurses, WINDOW *win)
 {
     EXPECT_CALL(ncurses, derwin(_, _, _, _, _)).WillRepeatedly(Return(win));
     EXPECT_CALL(ncurses, delwin(_)).WillOnce(Return(OK));
+    EXPECT_CALL(ncurses, w_add_str(_, _)).WillRepeatedly(Return(OK));
+    EXPECT_CALL(ncurses, wborder(_, _, _, _, _, _, _, _, _))
+        .WillRepeatedly(Return(OK));
 }
 
 void setup_config()
@@ -143,6 +146,16 @@ TEST_F(mock_tui_test, project_init_fails)
         .WillOnce(Return(nullptr));
     term.init();
     ASSERT_EQ(term.return_code(), ERROR_DERWIN);
+}
+
+TEST_F(mock_tui_test, root_draw_fails)
+{
+    term.init();
+
+    EXPECT_CALL(ncurses, wborder(_, _, _, _, _, _, _, _, _))
+        .Times(1)
+        .WillOnce(Return(ERR));
+    ASSERT_EQ(term.draw(), ERR);
 }
 
 TEST(tui, pane_init_fails)

--- a/src/tests/window.test.cpp
+++ b/src/tests/window.test.cpp
@@ -95,6 +95,23 @@ TEST_F(window_test, stub_raii)
     ASSERT_EQ(ncurses.windows().size(), 1);
 }
 
+TEST_F(window_test, resize)
+{
+    using window_t = tui::window<ext::ncurses>;
+    auto window = std::make_shared<window_t>(ncurses, root);
+    ASSERT_EQ(window->init(), OK);
+
+    // Falls through to basic_window<CI>::resize(), which is a no-op
+    window->resize();
+}
+
+TEST_F(window_test, draw)
+{
+    using window_t = tui::window<ext::ncurses>;
+    auto window = std::make_shared<window_t>(ncurses, root);
+    ASSERT_EQ(window->draw(), ERROR_NOIMPL);
+}
+
 TEST_F(mock_window_test, subwin_fails)
 {
     using window_t = tui::window<ext::ncurses>;

--- a/src/tui/basic_window.hpp
+++ b/src/tui/basic_window.hpp
@@ -92,6 +92,11 @@ public:
         return m_win;
     }
 
+    virtual void resize() noexcept override
+    {
+        // no-op symbol definition for concrete class
+    }
+
     int refresh_all() noexcept
     {
         if (auto rc = refresh())

--- a/src/tui/object.hpp
+++ b/src/tui/object.hpp
@@ -18,6 +18,12 @@ public:
     //! init() interface which must be overridden in derivatives
     virtual int init() noexcept = 0;
 
+    //! resize() interface which should be overridden in derivatives
+    virtual void resize() noexcept = 0;
+
+    //! void() interface which must be overridden in derivatives
+    virtual int draw() noexcept = 0;
+
     //! refresh() interface which must be overridden in derivatives
     virtual int refresh() noexcept = 0;
 

--- a/src/tui/pane.hpp
+++ b/src/tui/pane.hpp
@@ -39,6 +39,15 @@ public:
         m_i = i;
     }
 
+    virtual int draw() noexcept override
+    {
+        // Draw focused child.
+        if (this->m_children.size()) {
+            this->m_children[m_i]->draw();
+        }
+        return OK;
+    }
+
     int refresh() noexcept final override
     {
         if (auto rc = window<CI>::refresh()) {

--- a/src/tui/project.hpp
+++ b/src/tui/project.hpp
@@ -17,6 +17,11 @@ private:
 public:
     using window<CI>::window;
 
+    virtual int draw() noexcept override
+    {
+        return OK;
+    }
+
     int id(int id)
     {
         this->m_project.id = id;

--- a/src/tui/root_window.hpp
+++ b/src/tui/root_window.hpp
@@ -41,11 +41,28 @@ public:
         return OK;
     }
 
+    virtual int draw() noexcept override
+    {
+        // Set a border on `root`.
+        if (auto rc = this->ncurses->wborder(this->handle(),
+                                             ACS_VLINE,
+                                             ACS_VLINE,
+                                             ACS_HLINE,
+                                             ACS_HLINE,
+                                             ACS_ULCORNER,
+                                             ACS_URCORNER,
+                                             ACS_LLCORNER,
+                                             ACS_LRCORNER)) {
+            return rc;
+        }
+        return OK;
+    }
+
     int refresh() noexcept final override
     {
-        if (!*this) {
-            return error(ERR,
-                         "root_window::refresh() called on a null handle");
+        if (!this->ncurses) {
+            return error(
+                ERR, "root_window::refresh() called on a null ncurses handle");
         }
 
         return this->ncurses->refresh();

--- a/src/tui/window.hpp
+++ b/src/tui/window.hpp
@@ -69,6 +69,11 @@ public:
         return std::make_tuple(m_x_offset, m_y_offset);
     }
 
+    virtual int draw() noexcept override
+    {
+        return ERROR_NOIMPL;
+    }
+
     int init() noexcept override
     {
         if (!this->ncurses) {


### PR DESCRIPTION
```
commit 5155a4182a91e910b6794aacf731bbbbe4fb51e3
Author: Kevin Morris <kevr@0cost.org>
Date:   Tue Aug 30 11:26:15 2022 -0700

    feat: support KEY_RESIZE, introduce object::{draw,resize}()
    
    This change brings in two new pure virtual functions in the
    `object` base:
    - `virtual void object::resize() noexcept = 0`
        - `object::resize()` is initially overridden in `basic_window<CI>`.
    - `virtual int object::draw() noexcept = 0`
        - `object::draw()` is initially overridden in `window<CI>`.
    
    KEY_RESIZE is now bound to:
    1. Erasing the root window's contents
    2. Ending all windows (delwin/endwin)
    3. Refreshing ncurses
    4. Initializing all windows (initscr/derwin)
        - Includes drawing all windows on initialization
    
    We've also mocked up `getchar()` to control KEY_RESIZE with
    this commit, which required updating some tests to mock it
    properly.
    
    Brings in:
    - `tasker_error::ERROR_NOIMPL`
        - An error indicating "no defined implementation"
    
    Signed-off-by: Kevin Morris <kevr@0cost.org>

commit a4e498238f84d90483c51d685e4d59893ef32744
Author: Kevin Morris <kevr@0cost.org>
Date:   Tue Aug 30 10:10:16 2022 -0700

    feat(ncurses): add werase(...)
    
    Signed-off-by: Kevin Morris <kevr@0cost.org>
```