### PR TITLE
feat: add color support, starting with color.root_border

### DIFF
--- a/doc/config.txt
+++ b/doc/config.txt
@@ -14,6 +14,10 @@
 # during the program's lifetime.
 #logfile = /path/to/logfile.txt
 
+# Enable debug logging by setting this option to 1.
+# It defaults to off (0).
+#debug = 0
+
 ## Keybindings
 # The `key_quit` option controls which keypress is bound
 # to quitting the program.

--- a/doc/config.txt
+++ b/doc/config.txt
@@ -18,3 +18,11 @@
 # The `key_quit` option controls which keypress is bound
 # to quitting the program.
 #key_quit = q
+
+## Colorscheme
+# The `color` section contains config options for every color
+# used in the program.
+# Each color option value should be a valid 8/256-color ordinal.
+[color]
+# By default, the root_border is blue (4).
+#root_border = 4

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1,6 +1,7 @@
 #include "config.hpp"
 #include "../config.hpp"
 #include <algorithm>
+#include <fmt/format.h>
 #include <vector>
 using namespace tasker;
 namespace po = boost::program_options;
@@ -14,6 +15,7 @@ cfg::config::config() noexcept
     m_desc.add_options()("version,v", "print version string");
     m_desc.add_options()(
         "config,c", po::value<std::string>(), "custom config file path");
+    reset();
 }
 
 cfg::config &cfg::config::option(const std::string &key,
@@ -64,6 +66,9 @@ void cfg::config::reset()
 {
     m_vars.clear();
     m_config = std::make_shared<po::options_description>("Config options");
+    m_config->add_options()("color.root_border",
+                            po::value<short>()->default_value(4),
+                            "8/256 color ordinal");
 }
 
 cfg::config &cfg::config::ref(cfg::config &conf)

--- a/src/ext/ncurses.cpp
+++ b/src/ext/ncurses.cpp
@@ -85,6 +85,36 @@ int ext::ncurses::werase(WINDOW *win) noexcept
     return ::werase(win);
 }
 
+int ext::ncurses::start_color() noexcept
+{
+    return ::start_color();
+}
+
+int ext::ncurses::init_pair(short pair, short fg, short bg) noexcept
+{
+    return ::init_pair(pair, fg, bg);
+}
+
+int ext::ncurses::supported_colors() noexcept
+{
+    return COLORS;
+}
+
+bool ext::ncurses::has_colors() noexcept
+{
+    return ::has_colors();
+}
+
+int ext::ncurses::wattr_enable(WINDOW *win, int attrs) noexcept
+{
+    return wattron(win, attrs);
+}
+
+int ext::ncurses::wattr_disable(WINDOW *win, int attrs) noexcept
+{
+    return wattroff(win, attrs);
+}
+
 WINDOW *ext::ncurses::root() noexcept
 {
     return m_root;

--- a/src/ext/ncurses.hpp
+++ b/src/ext/ncurses.hpp
@@ -33,6 +33,15 @@ public:
                 chtype, chtype) noexcept;
     int werase(WINDOW *) noexcept;
 
+    // Color functions
+    int start_color() noexcept;
+    int init_pair(short, short, short) noexcept;
+    int supported_colors() noexcept;
+    bool has_colors() noexcept;
+
+    int wattr_enable(WINDOW *, int) noexcept;
+    int wattr_disable(WINDOW *, int) noexcept;
+
 public:
     WINDOW *root() noexcept;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,6 +85,10 @@ int tasker_main(ext::ncurses &ncurses, int argc, char *argv[])
     if (!term.init())
         return term.end();
 
+    auto message =
+        fmt::format("supported colors: {0}", ncurses.supported_colors());
+    logging.info(message);
+
     // Refresh the TUI
     term.refresh();
 

--- a/src/stubs/ncurses.cpp
+++ b/src/stubs/ncurses.cpp
@@ -105,6 +105,44 @@ int ext::ncurses::werase(WINDOW *win) noexcept
     return OK;
 }
 
+int ext::ncurses::start_color() noexcept
+{
+    return OK;
+}
+
+int ext::ncurses::init_pair(short pair, short fg, short bg) noexcept
+{
+    m_pairs[pair] = std::make_pair(fg, bg);
+    return OK;
+}
+
+int ext::ncurses::get_pair(short pair) noexcept
+{
+    if (m_pairs.find(pair) == m_pairs.end())
+        return ERR;
+    return pair;
+}
+
+int ext::ncurses::supported_colors() noexcept
+{
+    return 256;
+}
+
+bool ext::ncurses::has_colors() noexcept
+{
+    return true;
+}
+
+int ext::ncurses::wattr_enable(WINDOW *, int) noexcept
+{
+    return OK;
+}
+
+int ext::ncurses::wattr_disable(WINDOW *, int) noexcept
+{
+    return OK;
+}
+
 // Public utility functions
 const WINDOW *ext::ncurses::root() const noexcept
 {

--- a/src/stubs/ncurses.hpp
+++ b/src/stubs/ncurses.hpp
@@ -13,7 +13,7 @@ class WINDOW
 #define ERR -1
 #define OK 0
 
-using chtype = char;
+typedef unsigned chtype;
 
 #define ACS_VLINE '|'
 #define ACS_HLINE '_'
@@ -39,6 +39,9 @@ private:
     //! child -> parent map
     std::map<WINDOW *, WINDOW *> m_windows;
 
+    //! color pairs
+    std::map<short, std::pair<short, short>> m_pairs;
+
 public:
     virtual ~ncurses();
 
@@ -63,6 +66,18 @@ public:
                         chtype, chtype, chtype) noexcept;
     virtual int werase(WINDOW *) noexcept;
 
+    // Colors
+    virtual int start_color() noexcept;
+
+    virtual int init_pair(short, short, short) noexcept;
+    virtual int get_pair(short) noexcept;
+
+    virtual int supported_colors() noexcept;
+    virtual bool has_colors() noexcept;
+
+    virtual int wattr_enable(WINDOW *, int) noexcept;
+    virtual int wattr_disable(WINDOW *, int) noexcept;
+
 public:
     // Test utilities.
     const WINDOW *root() const noexcept;
@@ -71,5 +86,16 @@ public:
 };
 
 }; // namespace tasker::ext
+
+#define COLOR_PAIR(x) this->ncurses->get_pair(x)
+
+#define COLOR_BLACK 0
+#define COLOR_RED 1
+#define COLOR_GREEN 2
+#define COLOR_YELLOW 3
+#define COLOR_BLUE 4
+#define COLOR_MAGENTA 5
+#define COLOR_CYAN 6
+#define COLOR_WHITE 7
 
 #endif /* SRC_EXTERN_NCURSES_HPP */

--- a/src/tests/config.test.cpp
+++ b/src/tests/config.test.cpp
@@ -57,34 +57,19 @@ TEST(config, set_ref)
 
 TEST_F(config_test, usage)
 {
-    std::string expected = PROG + " [-hvc]";
+    std::string expected = PROG + " [-hvc] [--color.root_border]";
     ASSERT_EQ(conf.usage(), expected);
 }
 
 TEST_F(config_test, config_usage)
 {
     conf.option("test", "test help");
-    std::string expected = PROG + " [-hvc] [--test]";
+    std::string expected = PROG + " [-hvc] [--color.root_border] [--test]";
     ASSERT_EQ(conf.usage(), expected);
 }
 
 TEST_F(config_test, help)
 {
-    auto output = capture_ostream(conf);
-
-    auto lines = split(output, '\n');
-    ASSERT_EQ(lines.size(), 6);
-    ASSERT_EQ(lines[0], "");
-    ASSERT_EQ(lines[1], "Program options:");
-    ASSERT_NE(lines[2].find("-h [ --help ]"), std::string::npos);
-    ASSERT_NE(lines[3].find("-v [ --version ]"), std::string::npos);
-    ASSERT_NE(lines[4].find("-c [ --config ] arg"), std::string::npos);
-    ASSERT_EQ(lines[5], "");
-}
-
-TEST_F(config_test, config_help)
-{
-    conf.option("test", "test help");
     auto output = capture_ostream(conf);
 
     auto lines = split(output, '\n');
@@ -96,8 +81,27 @@ TEST_F(config_test, config_help)
     ASSERT_NE(lines[4].find("-c [ --config ] arg"), std::string::npos);
     ASSERT_EQ(lines[5], "");
     ASSERT_EQ(lines[6], "Config options:");
-    ASSERT_NE(lines[7].find("--test"), std::string::npos);
+    ASSERT_NE(lines[7].find("--color.root_border arg"), std::string::npos);
     ASSERT_EQ(lines[8], "");
+}
+
+TEST_F(config_test, config_help)
+{
+    conf.option("test", "test help");
+    auto output = capture_ostream(conf);
+
+    auto lines = split(output, '\n');
+    ASSERT_EQ(lines.size(), 10);
+    ASSERT_EQ(lines[0], "");
+    ASSERT_EQ(lines[1], "Program options:");
+    ASSERT_NE(lines[2].find("-h [ --help ]"), std::string::npos);
+    ASSERT_NE(lines[3].find("-v [ --version ]"), std::string::npos);
+    ASSERT_NE(lines[4].find("-c [ --config ] arg"), std::string::npos);
+    ASSERT_EQ(lines[5], "");
+    ASSERT_EQ(lines[6], "Config options:");
+    ASSERT_NE(lines[7].find("--color.root_border arg"), std::string::npos);
+    ASSERT_NE(lines[8].find("--test"), std::string::npos);
+    ASSERT_EQ(lines[9], "");
 }
 
 TEST_F(config_test, getattr)

--- a/src/tests/main.test.cpp
+++ b/src/tests/main.test.cpp
@@ -287,6 +287,8 @@ TEST_F(main_test, resize)
     EXPECT_CALL(ncurses, refresh()).WillRepeatedly(Return(OK));
     EXPECT_CALL(ncurses, wrefresh(_)).WillRepeatedly(Return(OK));
     EXPECT_CALL(ncurses, w_add_str(_, _)).WillRepeatedly(Return(OK));
+    EXPECT_CALL(ncurses, wborder(_, _, _, _, _, _, _, _, _))
+        .WillRepeatedly(Return(OK));
 
     EXPECT_CALL(ncurses, getchar())
         .Times(2)

--- a/src/tests/ncurses.test.cpp
+++ b/src/tests/ncurses.test.cpp
@@ -29,3 +29,9 @@ TEST(ncurses, keypad)
     ncurses.keypad(&win, true);
     ASSERT_TRUE(ncurses.keypad(&win));
 }
+
+TEST(ncurses, get_pair_err)
+{
+    tasker::ext::ncurses ncurses;
+    ASSERT_EQ(ncurses.get_pair(1), ERR);
+}

--- a/src/tui.hpp
+++ b/src/tui.hpp
@@ -4,6 +4,7 @@
 #include "config/config.hpp"
 #include "errors.hpp"
 #include "logging.hpp"
+#include "tui/color.hpp"
 #include "tui/pane.hpp"
 #include "tui/project.hpp"
 #include "tui/window.hpp"
@@ -87,6 +88,14 @@ public:
         if (auto rc = ncurses.noecho()) {
             m_return_code = error(ERROR_ECHO, "noecho() failed: ", rc);
             return *this;
+        }
+
+        if (ncurses.has_colors()) {
+            auto &conf = cfg::config::ref();
+            auto color = conf.get<short>("color.root_border");
+
+            ncurses.start_color();
+            ncurses.init_pair(theme::root_border, color, COLOR_BLACK);
         }
 
         m_pane->inherit();  // Update sizes relative to the root
@@ -174,8 +183,8 @@ public:
         m_pane->end();
 
         // Just destruct the root window in all cases; in the case where we
-        // error out after running initscr(), this will be able to undo what
-        // initscr() did if it can.
+        // error out after running initscr(), this will be able to undo
+        // what initscr() did if it can.
         auto rc = root->end();
 
         // Only update m_return_code if it's not already errored out.

--- a/src/tui/color.hpp
+++ b/src/tui/color.hpp
@@ -1,0 +1,13 @@
+#ifndef SRC_TUI_COLOR_HPP
+#define SRC_TUI_COLOR_HPP
+
+namespace tasker::tui
+{
+
+enum theme : short {
+    root_border = 1,
+};
+
+}; // namespace tasker::tui
+
+#endif /* SRC_TUI_COLOR_HPP */

--- a/src/tui/root_window.hpp
+++ b/src/tui/root_window.hpp
@@ -4,6 +4,7 @@
 #include "../errors.hpp"
 #include "../utility.hpp"
 #include "basic_window.hpp"
+#include "tui/color.hpp"
 
 namespace tasker::tui
 {
@@ -44,18 +45,19 @@ public:
     virtual int draw() noexcept override
     {
         // Set a border on `root`.
-        if (auto rc = this->ncurses->wborder(this->handle(),
-                                             ACS_VLINE,
-                                             ACS_VLINE,
-                                             ACS_HLINE,
-                                             ACS_HLINE,
-                                             ACS_ULCORNER,
-                                             ACS_URCORNER,
-                                             ACS_LLCORNER,
-                                             ACS_LRCORNER)) {
-            return rc;
-        }
-        return OK;
+        auto pair = COLOR_PAIR(theme::root_border);
+        this->ncurses->wattr_enable(this->m_win, pair);
+        int rc = this->ncurses->wborder(this->handle(),
+                                        ACS_VLINE,
+                                        ACS_VLINE,
+                                        ACS_HLINE,
+                                        ACS_HLINE,
+                                        ACS_ULCORNER,
+                                        ACS_URCORNER,
+                                        ACS_LLCORNER,
+                                        ACS_LRCORNER);
+        this->ncurses->wattr_disable(this->m_win, pair);
+        return rc;
     }
 
     int refresh() noexcept final override


### PR DESCRIPTION
```
commit 50ed7785b1e27a19b41474535df3d8e952f3b3e0
Author: Kevin Morris <kevr@0cost.org>
Date:   Tue Aug 30 13:34:34 2022 -0700

    doc: add debug info to doc/config.txt
    
    Signed-off-by: Kevin Morris <kevr@0cost.org>

commit 39a006b626b544d7182d7f41d7b34720ab29808b
Author: Kevin Morris <kevr@0cost.org>
Date:   Tue Aug 30 13:33:08 2022 -0700

    feat: add color support, starting with color.root_border
    
    The root window border is now colored using the 8/256-color code
    value for the `color.root_border` option.
    
    This is the beginning of color support in the program. We will
    continue using this style of color configuration as pieces
    are added to the interface.
    
    Signed-off-by: Kevin Morris <kevr@0cost.org>

commit 31909557506b165e6b9b7a3329ef2c2e9a2f581b
Author: Kevin Morris <kevr@0cost.org>
Date:   Tue Aug 30 12:28:00 2022 -0700

    fix(main.test.cpp): mock wborder during resize
    
    Signed-off-by: Kevin Morris <kevr@0cost.org>
```