### PR TITLE
fix: remove ERROR/SUCCESS enums

### DIFF
--- a/src/errors.hpp
+++ b/src/errors.hpp
@@ -4,8 +4,8 @@
 #include "ncurses.hpp"
 
 enum tasker_error : int {
-    ERROR = ERR,
-    SUCCESS = OK,
+    // ERR is accessible via ncurses
+    // OK is accessible via ncurses
     ERROR_INITSCR = 1,
     ERROR_KEYPAD = 2,
     ERROR_RAW = 3,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,12 +39,12 @@ int tasker_main(ext::ncurses &ncurses, int argc, char *argv[])
     if (conf.exists("help")) {
         std::cout << "usage: " << conf.usage() << std::endl
                   << conf << std::endl;
-        return SUCCESS;
+        return OK;
     }
 
     if (conf.exists("version")) {
         std::cout << VERSION << std::endl;
-        return SUCCESS;
+        return OK;
     }
 
     std::optional<std::filesystem::path> path;

--- a/src/tests/main.test.cpp
+++ b/src/tests/main.test.cpp
@@ -147,7 +147,7 @@ TEST_F(main_test, runs)
     auto argv = const_cast<char **>(_argv);
 
     auto rc = main_real(1, argv);
-    ASSERT_EQ(rc, SUCCESS);
+    ASSERT_EQ(rc, OK);
 }
 
 TEST_F(main_test, help)
@@ -158,7 +158,7 @@ TEST_F(main_test, help)
     auto argv = const_cast<char **>(_argv);
 
     auto rc = main_real(2, argv);
-    ASSERT_EQ(rc, SUCCESS);
+    ASSERT_EQ(rc, OK);
 
     auto output = testing::internal::GetCapturedStdout();
     auto lines = split(output, '\n');
@@ -180,7 +180,7 @@ TEST_F(main_test, version)
     auto argv = const_cast<char **>(_argv);
 
     auto rc = main_real(2, argv);
-    ASSERT_EQ(rc, SUCCESS);
+    ASSERT_EQ(rc, OK);
 
     auto output = strip(testing::internal::GetCapturedStdout(), '\n');
     ASSERT_EQ(output, VERSION);
@@ -199,7 +199,7 @@ TEST_F(main_test, custom_config)
     int argc = 3;
 
     auto rc = main_real(argc, argv);
-    ASSERT_EQ(rc, SUCCESS);
+    ASSERT_EQ(rc, OK);
 }
 
 TEST_F(main_test, custom_config_unknown_option)

--- a/src/tui/root_window.hpp
+++ b/src/tui/root_window.hpp
@@ -24,7 +24,7 @@ public:
     int init() noexcept final override
     {
         if (!this->ncurses) {
-            return error(ERROR, "root_window::ncurses was null during init()");
+            return error(ERR, "root_window::ncurses was null during init()");
         }
 
         this->m_win = this->ncurses->initscr();

--- a/src/tui/window.hpp
+++ b/src/tui/window.hpp
@@ -77,7 +77,7 @@ public:
     int init() noexcept override
     {
         if (!this->ncurses) {
-            return error(ERROR, "window::ncurses was null during init()");
+            return error(ERR, "window::ncurses was null during init()");
         }
 
         int y = this->m_y - (this->m_padding * 2);


### PR DESCRIPTION
These aren't needed. ncurses (and its stub implementation) provides
ERR and OK defines which should be used in place of these.

Signed-off-by: Kevin Morris <kevr@0cost.org>