### PR TITLE
add tui::project status bar

### DIFF
--- a/doc/config.txt
+++ b/doc/config.txt
@@ -30,3 +30,9 @@
 [color]
 # By default, the root_border is blue (4).
 #root_border = 4
+
+# Project status bar foreground
+#project_bar_fg = 0
+
+# Project status bar background
+#project_bar_bg = 4

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -69,6 +69,12 @@ void cfg::config::reset()
     m_config->add_options()("color.root_border",
                             po::value<short>()->default_value(4),
                             "8/256 color ordinal");
+    m_config->add_options()("color.project_bar_bg",
+                            po::value<short>()->default_value(4),
+                            "8/256 color ordinal");
+    m_config->add_options()("color.project_bar_fg",
+                            po::value<short>()->default_value(0),
+                            "8/256 color ordinal");
 }
 
 cfg::config &cfg::config::ref(cfg::config &conf)

--- a/src/tests/config.test.cpp
+++ b/src/tests/config.test.cpp
@@ -57,14 +57,18 @@ TEST(config, set_ref)
 
 TEST_F(config_test, usage)
 {
-    std::string expected = PROG + " [-hvc] [--color.root_border]";
+    std::string expected =
+        PROG + (" [-hvc] [--color.root_border] [--color.project_bar_bg] "
+                "[--color.project_bar_fg]");
     ASSERT_EQ(conf.usage(), expected);
 }
 
 TEST_F(config_test, config_usage)
 {
     conf.option("test", "test help");
-    std::string expected = PROG + " [-hvc] [--color.root_border] [--test]";
+    std::string expected =
+        PROG + (" [-hvc] [--color.root_border] [--color.project_bar_bg] "
+                "[--color.project_bar_fg] [--test]");
     ASSERT_EQ(conf.usage(), expected);
 }
 
@@ -73,7 +77,7 @@ TEST_F(config_test, help)
     auto output = capture_ostream(conf);
 
     auto lines = split(output, '\n');
-    ASSERT_EQ(lines.size(), 9);
+    ASSERT_EQ(lines.size(), 11);
     ASSERT_EQ(lines[0], "");
     ASSERT_EQ(lines[1], "Program options:");
     ASSERT_NE(lines[2].find("-h [ --help ]"), std::string::npos);
@@ -82,7 +86,9 @@ TEST_F(config_test, help)
     ASSERT_EQ(lines[5], "");
     ASSERT_EQ(lines[6], "Config options:");
     ASSERT_NE(lines[7].find("--color.root_border arg"), std::string::npos);
-    ASSERT_EQ(lines[8], "");
+    ASSERT_NE(lines[8].find("--color.project_bar_bg arg"), std::string::npos);
+    ASSERT_NE(lines[9].find("--color.project_bar_fg arg"), std::string::npos);
+    ASSERT_EQ(lines[10], "");
 }
 
 TEST_F(config_test, config_help)
@@ -91,7 +97,7 @@ TEST_F(config_test, config_help)
     auto output = capture_ostream(conf);
 
     auto lines = split(output, '\n');
-    ASSERT_EQ(lines.size(), 10);
+    ASSERT_EQ(lines.size(), 12);
     ASSERT_EQ(lines[0], "");
     ASSERT_EQ(lines[1], "Program options:");
     ASSERT_NE(lines[2].find("-h [ --help ]"), std::string::npos);
@@ -100,8 +106,10 @@ TEST_F(config_test, config_help)
     ASSERT_EQ(lines[5], "");
     ASSERT_EQ(lines[6], "Config options:");
     ASSERT_NE(lines[7].find("--color.root_border arg"), std::string::npos);
-    ASSERT_NE(lines[8].find("--test"), std::string::npos);
-    ASSERT_EQ(lines[9], "");
+    ASSERT_NE(lines[8].find("--color.project_bar_bg arg"), std::string::npos);
+    ASSERT_NE(lines[9].find("--color.project_bar_fg arg"), std::string::npos);
+    ASSERT_NE(lines[10].find("--test"), std::string::npos);
+    ASSERT_EQ(lines[11], "");
 }
 
 TEST_F(config_test, getattr)

--- a/src/tests/main.test.cpp
+++ b/src/tests/main.test.cpp
@@ -279,9 +279,7 @@ TEST_F(main_test, resize)
     EXPECT_CALL(ncurses, endwin()).WillRepeatedly(Return(OK));
 
     WINDOW child;
-    EXPECT_CALL(ncurses, derwin(_, _, _, _, _))
-        .Times(4)
-        .WillRepeatedly(Return(&child));
+    EXPECT_CALL(ncurses, derwin(_, _, _, _, _)).WillRepeatedly(Return(&child));
     EXPECT_CALL(ncurses, delwin(_)).WillRepeatedly(Return(OK));
 
     EXPECT_CALL(ncurses, refresh()).WillRepeatedly(Return(OK));

--- a/src/tui/bar.hpp
+++ b/src/tui/bar.hpp
@@ -1,0 +1,62 @@
+#ifndef SRC_TUI_BAR_HPP
+#define SRC_TUI_BAR_HPP
+
+#include "color.hpp"
+#include "config.hpp"
+#include "config/config.hpp"
+#include "window.hpp"
+
+namespace tasker::tui
+{
+
+template <typename CI>
+class bar : public window<CI>
+{
+private:
+    logger logging;
+
+public:
+    using window<CI>::window;
+
+    virtual int init() noexcept override
+    {
+        logging.info("bar::init()");
+        return window<CI>::init();
+    }
+
+    bar &inherit()
+    {
+        auto [x, _] = this->m_parent->dimensions();
+
+        int padding = this->m_parent->padding();
+        this->m_x = x - (padding * 2);
+        this->m_y = 1;
+
+        this->offset(0, 0);
+
+        return *this;
+    }
+
+    virtual int draw() noexcept override
+    {
+        auto color = COLOR_PAIR(theme::project_bar);
+        this->ncurses->wattr_enable(this->handle(), color);
+        auto [x, _] = this->dimensions();
+        auto status = fmt::format("{0} {1}", PROG, VERSION);
+        std::string spaces(x - status.size(), ' ');
+        status += spaces;
+        this->ncurses->w_add_str(this->handle(), status.c_str());
+        this->ncurses->wattr_disable(this->handle(), color);
+        return OK;
+    }
+
+    virtual int refresh() noexcept override
+    {
+        logging.debug("bar::refresh()");
+        return window<CI>::refresh();
+    }
+};
+
+}; // namespace tasker::tui
+
+#endif /* SRC_TUI_BAR_HPP */

--- a/src/tui/basic_window.hpp
+++ b/src/tui/basic_window.hpp
@@ -58,7 +58,7 @@ public:
     // Defaulted destructor override.
     virtual ~basic_window() noexcept = default;
 
-    basic_window &dimensions(int x, int y)
+    basic_window &set_dimensions(int x, int y)
     {
         m_x = x;
         m_y = y;

--- a/src/tui/basic_window.hpp
+++ b/src/tui/basic_window.hpp
@@ -97,6 +97,11 @@ public:
         // no-op symbol definition for concrete class
     }
 
+    int erase() noexcept
+    {
+        return this->ncurses->werase(this->handle());
+    }
+
     int refresh_all() noexcept
     {
         if (auto rc = refresh())

--- a/src/tui/color.hpp
+++ b/src/tui/color.hpp
@@ -6,6 +6,7 @@ namespace tasker::tui
 
 enum theme : short {
     root_border = 1,
+    project_bar = 2,
 };
 
 }; // namespace tasker::tui

--- a/src/tui/pane.hpp
+++ b/src/tui/pane.hpp
@@ -15,10 +15,18 @@ class pane : public window<CI>
 private:
     size_t m_i = 0;
 
+    logger logging;
+
 public:
     using window<CI>::window;
 
     ~pane() = default;
+
+    virtual int init() noexcept override
+    {
+        logging.info("pane::init()");
+        return window<CI>::init();
+    }
 
     void focus(size_t i)
     {
@@ -43,13 +51,17 @@ public:
     {
         // Draw focused child.
         if (this->m_children.size()) {
-            this->m_children[m_i]->draw();
+            if (auto rc = this->m_children[m_i]->draw()) {
+                return rc;
+            }
         }
         return OK;
     }
 
     int refresh() noexcept final override
     {
+        logging.debug("pane::refresh()");
+
         if (auto rc = window<CI>::refresh()) {
             return rc;
         }

--- a/src/tui/project.hpp
+++ b/src/tui/project.hpp
@@ -1,6 +1,8 @@
 #ifndef SRC_TUI_PROJECT_HPP
 #define SRC_TUI_PROJECT_HPP
 
+#include "bar.hpp"
+#include "pane.hpp"
 #include "projects/project.hpp"
 #include "window.hpp"
 
@@ -14,11 +16,63 @@ private:
     using window_t = window<CI>;
     using window_ptr = std::shared_ptr<window_t>;
 
+    using bar_t = bar<CI>;
+    std::shared_ptr<bar_t> m_bar;
+
+    using pane_t = pane<CI>;
+    std::shared_ptr<pane_t> m_content;
+
+    logger logging;
+
 public:
     using window<CI>::window;
 
+    virtual int init() noexcept override
+    {
+        logging.info("project::init()");
+        this->inherit();
+        if (auto rc = window<CI>::init()) {
+            return rc;
+        }
+
+        m_bar =
+            std::make_shared<bar_t>(*this->ncurses, this->shared_from_this());
+        m_bar->inherit();
+        if (auto rc = m_bar->init()) {
+            return rc;
+        }
+
+        m_content =
+            std::make_shared<pane_t>(*this->ncurses, this->shared_from_this());
+        m_content->inherit();
+
+        auto [x, y] = this->m_content->dimensions();
+        m_content->set_dimensions(x, y - 1);
+        m_content->offset(0, 1);
+        if (auto rc = m_content->init()) {
+            return rc;
+        }
+
+        return OK;
+    }
+
     virtual int draw() noexcept override
     {
+        m_bar->draw();
+        auto &conf = cfg::config::ref();
+        auto key_quit = conf.get<char>("key_quit");
+        auto message = fmt::format("Press '{0}' to quit...", key_quit);
+        if (auto rc = this->ncurses->w_add_str(m_content->handle(),
+                                               message.c_str())) {
+            return error(ERROR_WADDSTR, "w_add_str() failed: ", rc);
+        }
+        return OK;
+    }
+
+    virtual int refresh() noexcept override
+    {
+        m_bar->refresh();
+        m_content->refresh();
         return OK;
     }
 

--- a/src/tui/root_window.hpp
+++ b/src/tui/root_window.hpp
@@ -37,7 +37,7 @@ public:
         if (x == -1) {
             return error(ERROR_GETMAXYX, "get_max_yx() failed");
         }
-        this->dimensions(x, y);
+        this->set_dimensions(x, y);
 
         return OK;
     }

--- a/src/tui/window.hpp
+++ b/src/tui/window.hpp
@@ -19,8 +19,10 @@ private:
     template <typename T>
     using basic_window_ptr = std::shared_ptr<basic_window<T>>;
 
+protected:
     basic_window_ptr<CI> m_parent;
 
+private:
     // Offsets
     int m_x_offset { 0 };
     int m_y_offset { 0 };


### PR DESCRIPTION
```
commit ed1d09841b5cf2d69c432f6b33a463b2fda487d2
Author: Kevin Morris <kevr@0cost.org>
Date:   Tue Aug 30 17:08:12 2022 -0700

    feat: add tui::project status bar
    
    new classes:
    - `tui::bar<CI>`
    
    add two windows to tui::project:
    - `tui::bar<CI>`
        - Status bar
    - `tui::pane<CI>`
        - Content pane
    
    add utility functions:
    - `basic_window<CI>::erase`
    
    added new options:
    - `color.project_bar_bg`
        - Background color of the project status bar
    - `color.project_bar_fg`
        - Foreground color of the project status bar
    
    also:
    - reworked draw() and some refresh connections
    
    updated doc/config.txt to describe the new options.
    
    Signed-off-by: Kevin Morris <kevr@0cost.org>

commit 32f9aae7271e02bba4215ee4abcb9a68830cc522
Author: Kevin Morris <kevr@0cost.org>
Date:   Tue Aug 30 17:07:18 2022 -0700

    change: basic_window<CI>::dimensions(int, int) -> set_dimensions(int, int)
    
    Signed-off-by: Kevin Morris <kevr@0cost.org>
```